### PR TITLE
docs(hutch): shorten the trial reminder funding line

### DIFF
--- a/projects/hutch/src/runtime/web/auth/trial-reminder-email.test.ts
+++ b/projects/hutch/src/runtime/web/auth/trial-reminder-email.test.ts
@@ -63,14 +63,12 @@ describe("TrialReminderEmail", () => {
 			expect(text).toContain("your account goes read-only.");
 		});
 
-		it("says what a subscription funds: the cloud bills, Readplace, and the blog", () => {
+		it("says what a subscription funds: the running expenses", () => {
 			const text = TrialReminderEmail(baseParams).to("text/plain");
 			expect(text).toContain(
 				"There's no company behind Readplace — no investors, no team, just me.",
 			);
-			expect(text).toContain(
-				"A subscription covers the cloud bills and pays for the hours that go into building Readplace and writing the posts on the blog, which stay free to read.",
-			);
+			expect(text).toContain("A subscription covers the running expenses.");
 		});
 
 		it("still says what a subscription funds when the user saved nothing", () => {
@@ -125,7 +123,7 @@ describe("TrialReminderEmail", () => {
 		it("renders the funding paragraph as its own <p>", () => {
 			const html = TrialReminderEmail(baseParams).to("text/html");
 			expect(html).toMatch(
-				/<p[^>]*>There's no company behind Readplace — no investors, no team, just me\. A subscription covers the cloud bills and pays for the hours that go into building Readplace and writing the posts on the blog, which stay free to read\.<\/p>/,
+				/<p[^>]*>There's no company behind Readplace — no investors, no team, just me\. A subscription covers the running expenses\.<\/p>/,
 			);
 		});
 

--- a/projects/hutch/src/runtime/web/auth/trial-reminder-email.ts
+++ b/projects/hutch/src/runtime/web/auth/trial-reminder-email.ts
@@ -35,7 +35,7 @@ function usageClause(count: number): string {
 function bodyParagraphs(clause: string): string[] {
 	return [
 		`Your trial of Readplace ends in ${TRIAL_REMINDER_LEAD_DAYS} days. I don't ask for a card up front, so nothing gets charged — when the trial ends your account goes read-only${clause ? `, but${clause}.` : "."}`,
-		"There's no company behind Readplace — no investors, no team, just me. A subscription covers the cloud bills and pays for the hours that go into building Readplace and writing the posts on the blog, which stay free to read.",
+		"There's no company behind Readplace — no investors, no team, just me. A subscription covers the running expenses.",
 		"If Readplace has earned a place in how you read, you can subscribe from your account page — it takes about a minute.",
 		"If it hasn't, no action needed. Either way, I'd genuinely like to know what would make it worth keeping: just reply. I respond to all replies personally.",
 	];


### PR DESCRIPTION
Rewrites the funding paragraph in the trial reminder email.

Before:

> There's no company behind Readplace — no investors, no team, just me. A subscription covers the cloud bills and pays for the hours that go into building Readplace and writing the posts on the blog, which stay free to read.

After:

> There's no company behind Readplace — no investors, no team, just me. A subscription covers the running expenses.

The sentence keeps the trailing full stop the surrounding body copy uses; the requested wording was otherwise verbatim.

## Changes

- `projects/hutch/src/runtime/web/auth/trial-reminder-email.ts` — the funding paragraph in `bodyParagraphs`.
- `projects/hutch/src/runtime/web/auth/trial-reminder-email.test.ts` — the three assertions pinned to the old wording (plain-text `toContain`, the HTML `<p>` regex, and the test name that itemised what the subscription funds).

Both the `text/plain` and `text/html` renderings come from the same paragraph array, so the one string change covers both.

## Verification

- `trial-reminder-email.test.ts` — 16 tests pass.
- `biome lint src` — clean.
- `tsc --project tsconfig.lint.json` and `check-unused-css` — pass.

`pnpm check` could not complete in the sandbox: `editorconfig-checker` downloads its Go binary from a GitHub release that this session's egress policy blocks (403), which reproduces on a clean tree with no changes applied. The pre-commit hook was bypassed with the author's approval for that reason. CI runs the full check on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UqvWf2E7ZURFTXqsT2vcE8

---
_Generated by [Claude Code](https://claude.ai/code/session_01UqvWf2E7ZURFTXqsT2vcE8)_