### PR TITLE
fix: resolve editorconfig-checker from the workspace bin in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
           firefox --version 2>/dev/null || echo "firefox: not on PATH"
           geckodriver --version 2>/dev/null | head -1 || echo "geckodriver: not on PATH"
 
-      - run: . ./.envrc && editorconfig-checker && pnpm nx run-many --target=check --all --exclude=ios,android
+      - run: . ./.envrc && pnpm exec editorconfig-checker && pnpm nx run-many --target=check --all --exclude=ios,android
 
   # Save-latency gate for both browser extensions: a save must paint the saved
   # view in under the measured budget on average.


### PR DESCRIPTION
## What

One line in the `web-tests` CI step: call the checker through `pnpm exec` instead of as a bare command.

## Why

`node_modules/.bin` is only on `PATH` inside a pnpm or npm script. The CI step runs the checker in a plain `bash -e` step, so the bare name does not resolve — the identical invocation in the root `check` script works locally for exactly that reason.

Every CI run on `main` since `ff1fcf97c` has died at exit 127 with `editorconfig-checker: command not found`, before a single test ran:

```
/persist/work/_temp/….sh: line 1: editorconfig-checker: command not found
##[error]Process completed with exit code 127.
```

Runs affected: `34096350172`, `34106738965`, `34107307743`, `34108188747`.

## Notes

`pnpm exec` keeps the persisted-binary step above it paying off, and the checker still picks up the `EC_VERSION` that `.envrc` exports. Verified locally that the bare name fails outside a pnpm script and that `pnpm exec editorconfig-checker --version` prints `v3.8.0`.

Unrelated to the change it was found on, so it ships on its own per the repo's rule for drive-by fixes.