### PR TITLE
[DUMMY] listener failure-reporter probe (pinned browsers) — do not merge

### DIFF
--- a/.github/actions/pinned-browsers/materialise.sh
+++ b/.github/actions/pinned-browsers/materialise.sh
@@ -16,6 +16,8 @@
 # the selenium chrome suites read those two files verbatim.
 set -euo pipefail
 
+exit 1 # [DUMMY PROBE] deliberate failure — verifies the listener names this step
+
 pin=".github/browser-image/image.env"
 test -f "$pin"
 set -a


### PR DESCRIPTION
Throwaway probe for `d2f12661`, following the PR #1024 pattern.

`materialise.sh` exits 1 on purpose, so `claude-listener.yml`'s `Use the pinned browsers` step fails — reproducing run `34311372401`.

**Expected:** the setup-failure comment reads ``failed at `pinned-browsers```, not `an unidentified step`.

Will be closed and the branch deleted once verified.