### PR TITLE
[DUMMY] listener failure-reporter probe (install dependencies) — do not merge

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ importers:
   .:
     devDependencies:
       '@biomejs/biome':
-        specifier: 2.4.16
+        specifier: 2.4.15
         version: 2.4.16
       '@types/jest':
         specifier: 30.0.0


### PR DESCRIPTION
Second throwaway probe for `d2f12661`, following the PR #1024 pattern.

The root biome specifier in `pnpm-lock.yaml` no longer matches `package.json`, so `pnpm install --frozen-lockfile` fails and `claude-listener.yml` dies at `Install dependencies`.

**Expected:** the setup-failure comment reads ``failed at `install-dependencies``` — a *different* step from PR #1116's `pinned-browsers`, which is what proves the reporter discriminates rather than printing a constant.

Will be closed and the branch deleted once verified.